### PR TITLE
SMST-103/feature/custom tlv support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ ebin
 .eunit
 *~
 .*.swp
+_build

--- a/include/smpp34pdu.hrl
+++ b/include/smpp34pdu.hrl
@@ -93,7 +93,8 @@
                     its_reply_type,
                     its_session_info,
                     ussd_service_op,
-                    ussd_session_id
+                    ussd_session_id,
+                    vendor_specific = #{}
                    }).
 
 -record(submit_sm_resp, {message_id=?DEFAULT_CSTRING, ussd_session_id}).

--- a/include/smpp34pdu_tlv_macros.hrl
+++ b/include/smpp34pdu_tlv_macros.hrl
@@ -5,9 +5,15 @@
 -define(TLV_UNPACK_UNEXPECTED(), unpack_tlv_fields(<<Unexpected:?TLV_TAG_SIZE, _/binary>>=Bin, Body) ->
     {_, Rest} = tlv:unpack(Unexpected, Bin),
     unpack_tlv_fields(Rest, Body)).
+-define(TLV_UNPACK_UNEXPECTED(RECORD_NAME), unpack_tlv_fields(<<Unexpected:?TLV_TAG_SIZE, _/binary>>=Bin, Body) ->
+    case tlv:unpack(Unexpected, Bin) of
+        {<<>>, Rest} -> unpack_tlv_fields(Rest, Body);
+        {Val, Rest} ->
+            #RECORD_NAME{vendor_specific = Vendor} = Body,
+            unpack_tlv_fields(Rest, Body#RECORD_NAME{vendor_specific= Vendor#{Unexpected => Val}})
+    end).
 -define(TLV_UNPACK_FIELD(RECORD_NAME,RECORD_FIELD,FIELD_TAG), unpack_tlv_fields(<<FIELD_TAG:?TLV_TAG_SIZE, _/binary>>=Bin, Body) ->
 	{Val, Rest} = tlv:unpack(FIELD_TAG, Bin),
     unpack_tlv_fields(Rest, Body#RECORD_NAME{RECORD_FIELD=Val})).
-
 
 -endif.

--- a/src/smpp34pdu_submit_sm.erl
+++ b/src/smpp34pdu_submit_sm.erl
@@ -55,7 +55,8 @@ pack(#submit_sm{service_type=SrvType,
 		its_reply_type=ItsReplyType,
 		its_session_info=ItsSessionInfo,
 		ussd_service_op=UssdServiceOp,
-                ussd_session_id=UssdSessionId}) ->
+                ussd_session_id=UssdSessionId,
+        vendor_specific = VendorSpecific }) ->
 
     SmLen = length(ShortMessage),
 
@@ -106,7 +107,8 @@ pack(#submit_sm{service_type=SrvType,
          tlv:pack(?ITS_REPLY_TYPE, ItsReplyType),
          tlv:pack(?ITS_SESSION_INFO, ItsSessionInfo),
          tlv:pack(?USSD_SERVICE_OP, UssdServiceOp),
-         tlv:pack(?USSD_SESSION_ID, UssdSessionId)],
+         tlv:pack(?USSD_SESSION_ID, UssdSessionId),
+         tlv:pack(VendorSpecific)],
 
     list_to_binary(L).
 
@@ -180,4 +182,4 @@ unpack(Bin0) ->
 ?TLV_UNPACK_FIELD(submit_sm, its_session_info, ?ITS_SESSION_INFO);
 ?TLV_UNPACK_FIELD(submit_sm, ussd_service_op, ?USSD_SERVICE_OP);
 ?TLV_UNPACK_FIELD(submit_sm, ussd_session_id, ?USSD_SESSION_ID);
-?TLV_UNPACK_UNEXPECTED().
+?TLV_UNPACK_UNEXPECTED(submit_sm).

--- a/src/tlv.erl
+++ b/src/tlv.erl
@@ -25,9 +25,9 @@
 -spec pack_octstring_fixedlen(integer(), binary(), integer()) -> binary().
 -spec pack_octstring_varlen(integer(), binary(), {integer(), integer()}) -> binary().
 -spec pack_octstring_nomax(integer(), binary()) -> binary().
--spec unpack_int(integer(), binary()) -> integer().
--spec unpack_cstring(integer(), binary()) -> iolist().
--spec unpack_octstring(integer(), binary()) -> binary().
+-spec unpack_int(integer(), binary()) -> {integer(), binary()}.
+-spec unpack_cstring(integer(), binary()) -> {iolist(), binary()}.
+-spec unpack_octstring(integer(), binary()) -> {binary(), binary()}.
 
 pack(_, undefined) ->
     <<>>;
@@ -314,7 +314,11 @@ unpack(?USSD_SESSION_ID=T, Bin) ->
     unpack_int(T, Bin);
 
 unpack(?IMSI=T, Bin) ->
-    unpack_cstring(T, Bin).
+    unpack_cstring(T, Bin);
+
+unpack(Tag, Bin) ->
+    discard_tag(Tag, Bin).
+
 
 pack_multi(_, undefined) ->
     <<>>;
@@ -400,3 +404,7 @@ unpack_cstring(Tag, <<Tag:?TLV_TAG_SIZE, Len:?TLV_LEN_SIZE, Val/binary>>) ->
 
 unpack_octstring(Tag, <<Tag:?TLV_TAG_SIZE, Len:?TLV_LEN_SIZE, Val/binary>>) ->
     pdu_data:bin_to_octstring(Val, Len).
+
+discard_tag(Tag, <<Tag:?TLV_TAG_SIZE, Len:?TLV_LEN_SIZE, Val/binary>>) ->
+    <<_:Len/unit:8, Rest/binary>> = Val,
+    {undefined, Rest}.

--- a/test/smpp34pdu_deliver_sm_resp_tests.erl
+++ b/test/smpp34pdu_deliver_sm_resp_tests.erl
@@ -2,8 +2,7 @@
 -include("../include/smpp34pdu.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
-
-deliver_sm_resp_test_() -> 
+deliver_sm_resp_test_() ->
     Payload = #deliver_sm_resp{message_id="abcdefghij"},
 
     Bin = <<97,98,99,100,101,102,103,104,105,106,0>>,
@@ -13,10 +12,10 @@ deliver_sm_resp_test_() ->
 			?_assertEqual(Bin,smpp34pdu_deliver_sm_resp:pack(Payload))},
 		{"Unpacking Bin will give Payload",
 			?_assertEqual(Payload, smpp34pdu_deliver_sm_resp:unpack(Bin))},
-		{"Packing and Unpacking Payload will give you Payload", 
+		{"Packing and Unpacking Payload will give you Payload",
 			?_assertEqual(Payload,
 					smpp34pdu_deliver_sm_resp:unpack(smpp34pdu_deliver_sm_resp:pack(Payload)))},
-		{"Unpacking and Packing Bin will give you Bin", 
+		{"Unpacking and Packing Bin will give you Bin",
 			?_assertEqual(Bin,
 					smpp34pdu_deliver_sm_resp:pack(smpp34pdu_deliver_sm_resp:unpack(Bin)))}
 	].

--- a/test/smpp34pdu_submit_sm_tests.erl
+++ b/test/smpp34pdu_submit_sm_tests.erl
@@ -158,7 +158,11 @@ submit_sm_custom_tlv_unpacking_test_() ->
 		sm_default_msg_id=1,
 		sm_length=11,
 		short_message="hello world",
-		source_port=11},
+		source_port=11,
+        vendor_specific = #{
+            2 => <<254, 253>>
+        }
+    },
 
 	Bin = <<67,77,84,0,
 			2,1,
@@ -171,9 +175,52 @@ submit_sm_custom_tlv_unpacking_test_() ->
 			1,1,1,1,11,
 			104,101,108,108,111,32,119,111,114,108,100,
 			2,10,0,2,0,11,
-            255,255,0,2,254,253>>,
+            0,2,0,2,254,253>>,
 
 	[
-		{"Unpacking Bin with custom TLV will give PayLoad without custom TLV",
+		{"Unpacking Bin with custom unsupported TLV will give PayLoad without custom TLV",
 			?_assertEqual(PayLoad, smpp34pdu_submit_sm:unpack(Bin))}
+	].
+
+submit_sm_custom_tlv_packing_test_() ->
+	PayLoad = #submit_sm{service_type="CMT",
+		source_addr_ton=2,
+		source_addr_npi=1,
+		source_addr="abcd",
+		dest_addr_ton=2,
+		dest_addr_npi=1,
+		destination_addr="efgh",
+		esm_class=1,
+		protocol_id=2,
+		priority_flag=1,
+		schedule_delivery_time="100716133059001+",
+		validity_period="000014000000000R",
+		registered_delivery=1,
+		replace_if_present_flag=1,
+		data_coding=1,
+		sm_default_msg_id=1,
+		sm_length=11,
+		short_message="hello world",
+		source_port=11,
+        vendor_specific = #{
+            2 => <<254, 253>>
+        }
+    },
+
+	Bin = <<67,77,84,0,
+			2,1,
+			97,98,99,100,0,
+			2,1,
+			101,102,103,104,0,
+			1,2,1,
+			$1,$0,$0,$7,$1,$6,$1,$3,$3,$0,$5,$9,$0,$0,$1,$+,0,
+			$0,$0,$0,$0,$1,$4,$0,$0,$0,$0,$0,$0,$0,$0,$0,$R,0,
+			1,1,1,1,11,
+			104,101,108,108,111,32,119,111,114,108,100,
+			2,10,0,2,0,11,
+            0,2,0,2,254,253>>,
+
+	[
+		{"Packing with custom TLV will honor custom TLVs",
+			?_assertEqual(Bin, smpp34pdu_submit_sm:pack(PayLoad))}
 	].

--- a/test/smpp34pdu_submit_sm_tests.erl
+++ b/test/smpp34pdu_submit_sm_tests.erl
@@ -42,7 +42,7 @@ submit_sm_no_tlv_test_() ->
 			?_assertEqual(PayLoad,
 						smpp34pdu_submit_sm:unpack(smpp34pdu_submit_sm:pack(PayLoad)))},
 		{"Unpacking and Packing Bin will give you Bin",
-			?_assertEqual(Bin, 
+			?_assertEqual(Bin,
 						smpp34pdu_submit_sm:pack(smpp34pdu_submit_sm:unpack(Bin)))}
 	].
 
@@ -78,7 +78,7 @@ submit_sm_tlv_usr_msg_ref_test_() ->
 			$0,$0,$0,$0,$1,$4,$0,$0,$0,$0,$0,$0,$0,$0,$0,$R,0,
 			1,1,1,1,11,
 			104,101,108,108,111,32,119,111,114,108,100,
-			2,4,0,2,0,4>>,	
+			2,4,0,2,0,4>>,
 
 	[
 		{"Packing PayLoad will give Bin",
@@ -89,7 +89,7 @@ submit_sm_tlv_usr_msg_ref_test_() ->
 			?_assertEqual(PayLoad,
 						smpp34pdu_submit_sm:unpack(smpp34pdu_submit_sm:pack(PayLoad)))},
 		{"Unpacking and Packing Bin will give you Bin",
-			?_assertEqual(Bin, 
+			?_assertEqual(Bin,
 						smpp34pdu_submit_sm:pack(smpp34pdu_submit_sm:unpack(Bin)))}
 	].
 
@@ -124,7 +124,7 @@ submit_sm_tlv_src_port_test_() ->
 			$0,$0,$0,$0,$1,$4,$0,$0,$0,$0,$0,$0,$0,$0,$0,$R,0,
 			1,1,1,1,11,
 			104,101,108,108,111,32,119,111,114,108,100,
-			2,10,0,2,0,11>>,	
+			2,10,0,2,0,11>>,
 
 	[
 		{"Packing PayLoad will give Bin",
@@ -135,6 +135,45 @@ submit_sm_tlv_src_port_test_() ->
 			?_assertEqual(PayLoad,
 						smpp34pdu_submit_sm:unpack(smpp34pdu_submit_sm:pack(PayLoad)))},
 		{"Unpacking and Packing Bin will give you Bin",
-			?_assertEqual(Bin, 
+			?_assertEqual(Bin,
 						smpp34pdu_submit_sm:pack(smpp34pdu_submit_sm:unpack(Bin)))}
+	].
+
+submit_sm_custom_tlv_unpacking_test_() ->
+	PayLoad = #submit_sm{service_type="CMT",
+		source_addr_ton=2,
+		source_addr_npi=1,
+		source_addr="abcd",
+		dest_addr_ton=2,
+		dest_addr_npi=1,
+		destination_addr="efgh",
+		esm_class=1,
+		protocol_id=2,
+		priority_flag=1,
+		schedule_delivery_time="100716133059001+",
+		validity_period="000014000000000R",
+		registered_delivery=1,
+		replace_if_present_flag=1,
+		data_coding=1,
+		sm_default_msg_id=1,
+		sm_length=11,
+		short_message="hello world",
+		source_port=11},
+
+	Bin = <<67,77,84,0,
+			2,1,
+			97,98,99,100,0,
+			2,1,
+			101,102,103,104,0,
+			1,2,1,
+			$1,$0,$0,$7,$1,$6,$1,$3,$3,$0,$5,$9,$0,$0,$1,$+,0,
+			$0,$0,$0,$0,$1,$4,$0,$0,$0,$0,$0,$0,$0,$0,$0,$R,0,
+			1,1,1,1,11,
+			104,101,108,108,111,32,119,111,114,108,100,
+			2,10,0,2,0,11,
+            255,255,0,2,254,253>>,
+
+	[
+		{"Unpacking Bin with custom TLV will give PayLoad without custom TLV",
+			?_assertEqual(PayLoad, smpp34pdu_submit_sm:unpack(Bin))}
 	].


### PR DESCRIPTION
The time has come for vendor-specific TLV support.
For now we need to proxy them from smsc to esme, therefore implemented packing and unpacking custom TLVs for `submit_sm` into `vendor_specific`   field, containing map of tags and corresponding binaries.
